### PR TITLE
PT186597010: New features for input select widget

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -215,12 +215,19 @@ The `Form Select` widget enables you to create single or multiple selection elem
 
 ### Properties
 
-- Input type: Choose the type of input, which can be single select (radio buttons or dropdown) or multi-select (checkboxes).
+- Input type: Choose the type of input, which can be single select (radio buttons, linear-scale or dropdown) or multi-select (checkboxes).
 - Label: Specify the label for the select input.
-- Items: Configure the items or options available for selection.
+- Items: Configure the items or options available for selection. (Not visible for input type linear-scale.)
 - Field name: Define the field name for the select input.
-- Mandatory: Indicates whether selection is required for single select inputs (radio buttons and dropdowns).
+- Mandatory: Indicates whether selection is required for single select inputs (radio buttons, linear-scale and dropdowns).
 - Help text: Provide optional help text for the select input.
+- Arrange items horizontally: When enabled, all items will be displayed in a single row. (Visible for checkboxes & radios only.)
+- Clear selection text: Allows the user to change the text of the button to clear the selection. (For radios & linear-scale if mandatory is set to false.)
+- Lower scale limit: Choose the lower limit, which can be either 0 or 1. (Visible for linear-scale only.)
+- Upper scale limit: Choose the upper limit, which can be from 2 to 10. (Visible for linear-scale only.)
+- Optional label for lower scale limit: Add text at the beginning of the linear scale. (Visible for linear-scale only.)
+- Optional label for upper scale limit: Set text at the end of the scale. (Visible for linear-scale only.)
+
 
 ### Validation
 - This select widget must be placed within a Form widget to be effective.

--- a/src/Widgets/FormSelectWidget/FormSelectWidget.scss
+++ b/src/Widgets/FormSelectWidget/FormSelectWidget.scss
@@ -25,6 +25,13 @@
   .dropdown-select {
     width: 100%;
   }
+  .inline {
+    flex-direction: row;
+    flex-wrap: nowrap;
+    & > * {
+      width: fit-content;
+    }
+  }
   .linear-scale-container {
     display: flex;
     align-items: flex-end;

--- a/src/Widgets/FormSelectWidget/FormSelectWidget.scss
+++ b/src/Widgets/FormSelectWidget/FormSelectWidget.scss
@@ -26,24 +26,26 @@
     width: 100%;
   }
   .inline {
+    display: flex;
     flex-direction: row;
     flex-wrap: nowrap;
     & > * {
-      width: fit-content;
+      padding-right: 1em;
     }
   }
   .linear-scale-container {
     display: flex;
-    align-items: flex-end;
     .lower-scale-label {
-      top: 5px;
+      top: 20px;
       position: relative;
       margin-right: 1.5em;
+      align-self: flex-start;
     }
     .upper-scale-label {
       top: 5px;
       position: relative;
       margin-left: 1.5em;
+      align-self: flex-end;
     }
     .linear-scale {
       flex-direction: column-reverse;

--- a/src/Widgets/FormSelectWidget/FormSelectWidget.scss
+++ b/src/Widgets/FormSelectWidget/FormSelectWidget.scss
@@ -1,3 +1,12 @@
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 .scrivito-neoletter-form-widgets .select-container {
   .select-title {
     display: flex;
@@ -15,5 +24,45 @@
   }
   .dropdown-select {
     width: 100%;
+  }
+  .linear-scale-container {
+    display: flex;
+    align-items: flex-end;
+    .lower-scale-label {
+      top: 5px;
+      position: relative;
+      margin-right: 1.5em;
+    }
+    .upper-scale-label {
+      top: 5px;
+      position: relative;
+      margin-left: 1.5em;
+    }
+    .linear-scale {
+      flex-direction: column-reverse;
+      width: auto;
+      span {
+        margin-left: 0;
+      }
+    }
+  }
+  .text-end {
+    margin-top: 0.5em;
+    .reset-label {
+      width: fit-content;
+      padding: 0.1em 0.6em;
+      display: inline-block;
+      border-radius: 2px;
+      cursor: pointer;
+      span {
+        color: #5f6368;
+      }
+      &:hover {
+        background-color: #f9f9f9;
+      }
+    }
+    &.fade-in {
+      animation: fadeIn 0.2s ease-in-out forwards;
+    }
   }
 }

--- a/src/Widgets/FormSelectWidget/FormSelectWidgetClass.ts
+++ b/src/Widgets/FormSelectWidget/FormSelectWidgetClass.ts
@@ -22,7 +22,7 @@ export const FormSelectWidget = Scrivito.provideWidgetClass(
       ],
       linearScaleLowerLabel: "string",
       linearScaleUpperLabel: "string",
-      clearSelectionLabel: "string",
+      clearSelectionText: "string",
     },
   },
 );

--- a/src/Widgets/FormSelectWidget/FormSelectWidgetClass.ts
+++ b/src/Widgets/FormSelectWidget/FormSelectWidgetClass.ts
@@ -23,6 +23,7 @@ export const FormSelectWidget = Scrivito.provideWidgetClass(
       linearScaleLowerLabel: "string",
       linearScaleUpperLabel: "string",
       clearSelectionText: "string",
+      inlineView: "boolean",
     },
   },
 );

--- a/src/Widgets/FormSelectWidget/FormSelectWidgetClass.ts
+++ b/src/Widgets/FormSelectWidget/FormSelectWidgetClass.ts
@@ -7,7 +7,7 @@ export const FormSelectWidget = Scrivito.provideWidgetClass(
       selectionType: [
         "enum",
         {
-          values: ["radio", "dropdown", "multi"],
+          values: ["radio", "dropdown", "multi", "linear-scale"],
         },
       ],
       title: "string",
@@ -15,6 +15,14 @@ export const FormSelectWidget = Scrivito.provideWidgetClass(
       customFieldName: "string",
       required: "boolean",
       helpText: "html",
+      linearScaleLowerLimit: ["enum", { values: ["0", "1"] }],
+      linearScaleUpperLimit: [
+        "enum",
+        { values: ["2", "3", "4", "5", "6", "7", "8", "9", "10"] },
+      ],
+      linearScaleLowerLabel: "string",
+      linearScaleUpperLabel: "string",
+      clearSelectionLabel: "string",
     },
   },
 );

--- a/src/Widgets/FormSelectWidget/FormSelectWidgetComponent.tsx
+++ b/src/Widgets/FormSelectWidget/FormSelectWidgetComponent.tsx
@@ -7,13 +7,16 @@ import { Mandatory } from "../FormStepContainerWidget/components/MandatoryCompon
 import { HelpText } from "../FormStepContainerWidget/components/HelpTextComponent";
 import { Dropdown } from "../FormStepContainerWidget/components/SelectDropdownComponent";
 import { FormSelectWidget } from "./FormSelectWidgetClass";
+import { ResetLabel } from "../FormStepContainerWidget/components/ResetLabelComponent";
 import "./FormSelectWidget.scss";
 
 Scrivito.provideComponent(FormSelectWidget, ({ widget }) => {
+  const ref = React.useRef<HTMLDivElement>(null);
+  const [selected, setSelected] = React.useState(false);
   const items = widget.get("items");
   const isMultiSelect = widget.get("selectionType") == "multi";
   const isDropdown = widget.get("selectionType") == "dropdown";
-  if (!items.length) {
+  if (!items.length && widget.get("selectionType") != "linear-scale") {
     return (
       <InPlaceEditingPlaceholder center>
         Add items in the widget properties.
@@ -22,7 +25,7 @@ Scrivito.provideComponent(FormSelectWidget, ({ widget }) => {
   }
 
   return (
-    <div className="select-container mb-3">
+    <div className="select-container mb-3" ref={ref}>
       <div className="select-title">
         <span className="text-super"> {widget.get("title")} </span>
         {!isMultiSelect && widget.get("required") && <Mandatory />}
@@ -38,11 +41,27 @@ Scrivito.provideComponent(FormSelectWidget, ({ widget }) => {
       ) : (
         <Select
           isMultiSelect={isMultiSelect}
-          items={widget.get("items")}
           required={widget.get("required")}
+          widget={widget}
           name={getFieldName(widget)}
+          onChange={() => setSelected(true)}
+        />
+      )}
+      {showResetLabel() && (
+        <ResetLabel
+          setSelectedCallback={setSelected}
+          label={widget.get("clearSelectionLabel")}
+          parentRef={ref}
         />
       )}
     </div>
   );
+  function showResetLabel(): boolean {
+    return (
+      selected &&
+      !widget.get("required") &&
+      (widget.get("selectionType") == "radio" ||
+        widget.get("selectionType") == "linear-scale")
+    );
+  }
 });

--- a/src/Widgets/FormSelectWidget/FormSelectWidgetComponent.tsx
+++ b/src/Widgets/FormSelectWidget/FormSelectWidgetComponent.tsx
@@ -7,7 +7,7 @@ import { Mandatory } from "../FormStepContainerWidget/components/MandatoryCompon
 import { HelpText } from "../FormStepContainerWidget/components/HelpTextComponent";
 import { Dropdown } from "../FormStepContainerWidget/components/SelectDropdownComponent";
 import { FormSelectWidget } from "./FormSelectWidgetClass";
-import { ResetLabel } from "../FormStepContainerWidget/components/ResetLabelComponent";
+import { ResetInputs } from "../FormStepContainerWidget/components/ResetInputsComponent";
 import "./FormSelectWidget.scss";
 
 Scrivito.provideComponent(FormSelectWidget, ({ widget }) => {
@@ -47,16 +47,16 @@ Scrivito.provideComponent(FormSelectWidget, ({ widget }) => {
           onChange={() => setSelected(true)}
         />
       )}
-      {showResetLabel() && (
-        <ResetLabel
+      {showReset() && (
+        <ResetInputs
           setSelectedCallback={setSelected}
-          label={widget.get("clearSelectionLabel")}
+          text={widget.get("clearSelectionText")}
           parentRef={ref}
         />
       )}
     </div>
   );
-  function showResetLabel(): boolean {
+  function showReset(): boolean {
     return (
       selected &&
       !widget.get("required") &&

--- a/src/Widgets/FormSelectWidget/FormSelectWidgetEditingConfig.ts
+++ b/src/Widgets/FormSelectWidget/FormSelectWidgetEditingConfig.ts
@@ -28,6 +28,10 @@ Scrivito.provideEditingConfig("FormSelectWidget", {
     linearScaleLowerLabel: { title: "Optional label for lower scale limit" },
     linearScaleUpperLabel: { title: "Optional label for upper scale limit" },
     clearSelectionText: { title: "Clear selection text" },
+    inlineView: {
+      title: "Arrange items horizontally",
+      description: "When enabled, all items will be displayed in a single row.",
+    },
   },
   properties: (widget) => {
     return getProps(widget);
@@ -40,6 +44,7 @@ Scrivito.provideEditingConfig("FormSelectWidget", {
     linearScaleLowerLimit: "1",
     linearScaleUpperLimit: "5",
     clearSelectionText: "Clear selection",
+    inlineView: false,
   },
   validations: [
     insideFormContainerValidation,
@@ -68,6 +73,10 @@ function getProps(widget: Scrivito.Obj): any[] {
     ["required", { enabled: type !== "multi" }],
     "helpText",
   ];
+  // show/hide inlineView
+  if (type == "radio" || type == "multi") {
+    props.splice(3, 0, "inlineView");
+  }
   // show/hide items
   if (type != "linear-scale") {
     props.splice(2, 0, "items");

--- a/src/Widgets/FormSelectWidget/FormSelectWidgetEditingConfig.ts
+++ b/src/Widgets/FormSelectWidget/FormSelectWidgetEditingConfig.ts
@@ -34,7 +34,7 @@ Scrivito.provideEditingConfig("FormSelectWidget", {
     },
   },
   properties: (widget) => {
-    return getProps(widget);
+    return getProperties(widget);
   },
   initialContent: {
     selectionType: "radio",
@@ -64,7 +64,7 @@ Scrivito.provideEditingConfig("FormSelectWidget", {
   ],
 });
 
-function getProps(widget: Scrivito.Obj): any[] {
+function getProperties(widget: Scrivito.Obj): any[] {
   const type = widget.get("selectionType");
   const props = [
     "selectionType",

--- a/src/Widgets/FormSelectWidget/FormSelectWidgetEditingConfig.ts
+++ b/src/Widgets/FormSelectWidget/FormSelectWidgetEditingConfig.ts
@@ -27,7 +27,7 @@ Scrivito.provideEditingConfig("FormSelectWidget", {
     linearScaleUpperLimit: { title: "Upper scale limit" },
     linearScaleLowerLabel: { title: "Optional label for lower scale limit" },
     linearScaleUpperLabel: { title: "Optional label for upper scale limit" },
-    clearSelectionLabel: { title: "Clear selection label" },
+    clearSelectionText: { title: "Clear selection text" },
   },
   properties: (widget) => {
     return getProps(widget);
@@ -39,7 +39,7 @@ Scrivito.provideEditingConfig("FormSelectWidget", {
     customFieldName: "custom_",
     linearScaleLowerLimit: "1",
     linearScaleUpperLimit: "5",
-    clearSelectionLabel: "Clear selection",
+    clearSelectionText: "Clear selection",
   },
   validations: [
     insideFormContainerValidation,
@@ -82,9 +82,9 @@ function getProps(widget: Scrivito.Obj): any[] {
       "linearScaleUpperLabel",
     );
   }
-  // show/hide clearSelectionLabel
+  // show/hide clearSelectionText
   if (!widget.get("required") && (type == "linear-scale" || type == "radio")) {
-    props.splice(props.length - 1, 0, "clearSelectionLabel");
+    props.splice(props.length - 1, 0, "clearSelectionText");
   }
   return props;
 }

--- a/src/Widgets/FormSelectWidget/FormSelectWidgetEditingConfig.ts
+++ b/src/Widgets/FormSelectWidget/FormSelectWidgetEditingConfig.ts
@@ -13,6 +13,7 @@ Scrivito.provideEditingConfig("FormSelectWidget", {
         { value: "radio", title: "Radio buttons" },
         { value: "dropdown", title: "Dropdown" },
         { value: "multi", title: "Checkboxes" },
+        { value: "linear-scale", title: "Linear scale" },
       ],
     },
     items: {
@@ -22,20 +23,23 @@ Scrivito.provideEditingConfig("FormSelectWidget", {
     customFieldName: { title: "Field name" },
     required: { title: "Mandatory" },
     helpText: { title: "Help text" },
+    linearScaleLowerLimit: { title: "Lower scale limit" },
+    linearScaleUpperLimit: { title: "Upper scale limit" },
+    linearScaleLowerLabel: { title: "Optional label for lower scale limit" },
+    linearScaleUpperLabel: { title: "Optional label for upper scale limit" },
+    clearSelectionLabel: { title: "Clear selection label" },
   },
-  properties: (widget) => [
-    "selectionType",
-    "title",
-    "items",
-    "customFieldName",
-    ["required", { enabled: widget.get("selectionType") !== "multi" }],
-    "helpText",
-  ],
+  properties: (widget) => {
+    return getProps(widget);
+  },
   initialContent: {
     selectionType: "radio",
     title: "Please choose",
     items: ["Yes", "No"],
     customFieldName: "custom_",
+    linearScaleLowerLimit: "1",
+    linearScaleUpperLimit: "5",
+    clearSelectionLabel: "Clear selection",
   },
   validations: [
     insideFormContainerValidation,
@@ -54,3 +58,33 @@ Scrivito.provideEditingConfig("FormSelectWidget", {
     customFieldNameValidation,
   ],
 });
+
+function getProps(widget: Scrivito.Obj): any[] {
+  const type = widget.get("selectionType");
+  const props = [
+    "selectionType",
+    "title",
+    "customFieldName",
+    ["required", { enabled: type !== "multi" }],
+    "helpText",
+  ];
+  // show/hide items
+  if (type != "linear-scale") {
+    props.splice(2, 0, "items");
+  } else {
+    // show/hide linear scale props
+    props.splice(
+      2,
+      0,
+      "linearScaleLowerLimit",
+      "linearScaleUpperLimit",
+      "linearScaleLowerLabel",
+      "linearScaleUpperLabel",
+    );
+  }
+  // show/hide clearSelectionLabel
+  if (!widget.get("required") && (type == "linear-scale" || type == "radio")) {
+    props.splice(props.length - 1, 0, "clearSelectionLabel");
+  }
+  return props;
+}

--- a/src/Widgets/FormStepContainerWidget/FormStepContainerWidget.scss
+++ b/src/Widgets/FormStepContainerWidget/FormStepContainerWidget.scss
@@ -89,6 +89,9 @@
 .bg-greydark,
 .bg-greymiddle {
   .missing-tenant,
+  .scrivito-neoletter-form-widgets.form-container-widget
+    .linear-scale-container,
+  .scrivito-neoletter-form-widgets.form-container-widget .reset-label span,
   .scrivito-neoletter-form-widgets.form-container-widget label,
   .scrivito-neoletter-form-widgets.form-container-widget .text-mandatory,
   .scrivito-neoletter-form-widgets.form-container-widget .bi,
@@ -109,6 +112,17 @@
   }
   .card .scrivito-neoletter-form-widgets.form-container-widget .bi {
     color: #ccc !important;
+  }
+}
+
+.bg-dark-image,
+.bg-brand-primary,
+.bg-brand-secondary,
+.bg-grey,
+.bg-greydark,
+.bg-greymiddle {
+  .scrivito-neoletter-form-widgets.form-container-widget .reset-label:hover {
+    background-color: unset;
   }
 }
 

--- a/src/Widgets/FormStepContainerWidget/components/LinearScaleComponent.tsx
+++ b/src/Widgets/FormStepContainerWidget/components/LinearScaleComponent.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import * as Scrivito from "scrivito";
+import { map, range } from "lodash-es";
+import { SelectItem } from "./SelectComponent";
+const LOWER_LIMIT_FALLBACK = 0;
+const UPPER_LIMIT_FALLBACK = 5;
+
+interface LinearScaleProps {
+  name: string;
+  widget: Scrivito.Widget;
+  onChange: React.ChangeEventHandler<HTMLInputElement>;
+}
+export const LinearScale: React.FC<LinearScaleProps> = Scrivito.connect(
+  ({ name, widget, onChange }) => {
+    const required = widget.get("required") as boolean;
+    const items = getScaleItems(widget);
+    const lowerScaleLabel = widget.get("linearScaleLowerLabel");
+    const upperScaleLabel = widget.get("linearScaleUpperLabel");
+    return (
+      <div className="linear-scale-container">
+        {lowerScaleLabel && (
+          <span className="lower-scale-label">{lowerScaleLabel as string}</span>
+        )}
+        <div className="row">
+          {items.map((itemValue, index) => (
+            <SelectItem
+              selectionType={"linear-scale"}
+              name={name}
+              value={itemValue}
+              required={required}
+              key={index}
+              onChange={onChange}
+            />
+          ))}
+        </div>
+        {upperScaleLabel && (
+          <span className="upper-scale-label">{upperScaleLabel as string}</span>
+        )}
+      </div>
+    );
+  },
+);
+
+function getScaleItems(widget: Scrivito.Widget): string[] {
+  const lowerLimit =
+    parseInt(widget.get("linearScaleLowerLimit") as string) ||
+    LOWER_LIMIT_FALLBACK;
+  const upperLimit =
+    parseInt(widget.get("linearScaleUpperLimit") as string) ||
+    UPPER_LIMIT_FALLBACK;
+
+  return map(range(lowerLimit, upperLimit + 1), (num) => num.toString());
+}

--- a/src/Widgets/FormStepContainerWidget/components/ResetInputsComponent.tsx
+++ b/src/Widgets/FormStepContainerWidget/components/ResetInputsComponent.tsx
@@ -1,16 +1,16 @@
 import * as React from "react";
 import { each } from "lodash-es";
 
-interface ResetLabelProps {
-  label: string;
+interface ResetInputsProps {
+  text: string;
   parentRef: React.RefObject<HTMLDivElement>;
   setSelectedCallback: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export const ResetLabel: React.FC<ResetLabelProps> = ({
+export const ResetInputs: React.FC<ResetInputsProps> = ({
   parentRef,
   setSelectedCallback,
-  label,
+  text,
 }) => {
   const doReset = () => {
     if (parentRef.current) {
@@ -29,7 +29,7 @@ export const ResetLabel: React.FC<ResetLabelProps> = ({
   return (
     <div className={`text-end  fade-in`}>
       <div className="reset-label" onClick={doReset}>
-        <span>{label}</span>
+        <span>{text}</span>
       </div>
     </div>
   );

--- a/src/Widgets/FormStepContainerWidget/components/ResetLabelComponent.tsx
+++ b/src/Widgets/FormStepContainerWidget/components/ResetLabelComponent.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { each } from "lodash-es";
+
+interface ResetLabelProps {
+  label: string;
+  parentRef: React.RefObject<HTMLDivElement>;
+  setSelectedCallback: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export const ResetLabel: React.FC<ResetLabelProps> = ({
+  parentRef,
+  setSelectedCallback,
+  label,
+}) => {
+  const doReset = () => {
+    if (parentRef.current) {
+      const inputs = parentRef.current.getElementsByTagName("input");
+      const inputArray = Array.from(inputs);
+      console.log(inputArray);
+      each(inputArray, (input) => {
+        if (input.type === "radio") {
+          input.checked = false;
+        }
+      });
+      setSelectedCallback(false);
+    }
+  };
+
+  return (
+    <div className={`text-end  fade-in`}>
+      <div className="reset-label" onClick={doReset}>
+        <span>{label}</span>
+      </div>
+    </div>
+  );
+};

--- a/src/Widgets/FormStepContainerWidget/components/SelectComponent.tsx
+++ b/src/Widgets/FormStepContainerWidget/components/SelectComponent.tsx
@@ -1,9 +1,12 @@
 import * as React from "react";
+import { Widget } from "scrivito";
+import { LinearScale } from "./LinearScaleComponent";
 interface SelectProps {
-  items: string[];
   isMultiSelect: boolean;
   required: boolean;
+  widget: Widget;
   name: string;
+  onChange: React.ChangeEventHandler<HTMLInputElement>;
 }
 interface SelectItemProps {
   selectionType: string;
@@ -15,23 +18,32 @@ interface SelectItemProps {
 }
 
 export const Select: React.FC<SelectProps> = ({
-  items,
   isMultiSelect,
   required,
+  widget,
   name,
+  onChange,
 }) => {
+  const type = widget.get("selectionType") as string;
+  if (type == "radio" || type == "multi") {
+    const items = widget.get("items") as string[];
+    return (
+      <div className="row">
+        {items.map((itemValue, index) => (
+          <SelectItem
+            selectionType={isMultiSelect ? "multi" : "radio"}
+            name={name}
+            value={itemValue}
+            required={required}
+            key={index}
+            onChange={onChange}
+          />
+        ))}
+      </div>
+    );
+  }
   return (
-    <div className="row">
-      {items.map((itemValue, index) => (
-        <SelectItem
-          selectionType={isMultiSelect ? "multi" : "radio"}
-          name={name}
-          value={itemValue}
-          required={required}
-          key={index}
-        />
-      ))}
-    </div>
+    <LinearScale name={name} widget={widget} onChange={onChange}></LinearScale>
   );
 };
 
@@ -44,12 +56,23 @@ export const SelectItem: React.FC<SelectItemProps> = ({
   onChange,
 }: SelectItemProps) => {
   return (
-    <label className="select-label">
+    <label
+      className={`select-label ${
+        selectionType == "linear-scale" ? "linear-scale" : ""
+      }`}
+    >
       <input
         className="form-check-input"
         name={name}
-        required={selectionType === "radio" && required}
-        type={selectionType == "radio" ? "radio" : "checkbox"}
+        required={
+          (selectionType == "radio" || selectionType == "linear-scale") &&
+          required
+        }
+        type={
+          selectionType == "radio" || selectionType == "linear-scale"
+            ? "radio"
+            : "checkbox"
+        }
         value={value}
         onChange={onChange}
         id={id}

--- a/src/Widgets/FormStepContainerWidget/components/SelectComponent.tsx
+++ b/src/Widgets/FormStepContainerWidget/components/SelectComponent.tsx
@@ -23,7 +23,7 @@ export const Select: React.FC<SelectProps> = Scrivito.connect(
     if (type == "radio" || type == "multi") {
       const items = widget.get("items") as string[];
       return (
-        <div className={`row ${widget.get("inlineView") ? "inline" : ""}`}>
+        <div className={`${widget.get("inlineView") ? "inline" : "row"}`}>
           {items.map((itemValue, index) => (
             <SelectItem
               selectionType={isMultiSelect ? "multi" : "radio"}

--- a/src/Widgets/FormStepContainerWidget/components/SelectComponent.tsx
+++ b/src/Widgets/FormStepContainerWidget/components/SelectComponent.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { Widget } from "scrivito";
+import * as Scrivito from "scrivito";
 import { LinearScale } from "./LinearScaleComponent";
 interface SelectProps {
   isMultiSelect: boolean;
   required: boolean;
-  widget: Widget;
+  widget: Scrivito.Widget;
   name: string;
   onChange: React.ChangeEventHandler<HTMLInputElement>;
 }
@@ -17,35 +17,35 @@ interface SelectItemProps {
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
 }
 
-export const Select: React.FC<SelectProps> = ({
-  isMultiSelect,
-  required,
-  widget,
-  name,
-  onChange,
-}) => {
-  const type = widget.get("selectionType") as string;
-  if (type == "radio" || type == "multi") {
-    const items = widget.get("items") as string[];
+export const Select: React.FC<SelectProps> = Scrivito.connect(
+  ({ isMultiSelect, required, widget, name, onChange }) => {
+    const type = widget.get("selectionType") as string;
+    if (type == "radio" || type == "multi") {
+      const items = widget.get("items") as string[];
+      return (
+        <div className={`row ${widget.get("inlineView") ? "inline" : ""}`}>
+          {items.map((itemValue, index) => (
+            <SelectItem
+              selectionType={isMultiSelect ? "multi" : "radio"}
+              name={name}
+              value={itemValue}
+              required={required}
+              key={index}
+              onChange={onChange}
+            />
+          ))}
+        </div>
+      );
+    }
     return (
-      <div className="row">
-        {items.map((itemValue, index) => (
-          <SelectItem
-            selectionType={isMultiSelect ? "multi" : "radio"}
-            name={name}
-            value={itemValue}
-            required={required}
-            key={index}
-            onChange={onChange}
-          />
-        ))}
-      </div>
+      <LinearScale
+        name={name}
+        widget={widget}
+        onChange={onChange}
+      ></LinearScale>
     );
-  }
-  return (
-    <LinearScale name={name} widget={widget} onChange={onChange}></LinearScale>
-  );
-};
+  },
+);
 
 export const SelectItem: React.FC<SelectItemProps> = ({
   selectionType,


### PR DESCRIPTION
Add new input type: linear-scale.
Add ability to show all items inline for radio & checkboxes
Show a reset/clear button for radios and linear-scale if mandatory is set to false.
Add new props to set lower/upper scale numbers and prefix/sufix scale texts