### PR TITLE
Add subsciption to hiddenFields

### DIFF
--- a/src/Widgets/FormHiddenFieldWidget/FormHiddenFieldWidgetClass.ts
+++ b/src/Widgets/FormHiddenFieldWidget/FormHiddenFieldWidgetClass.ts
@@ -11,6 +11,12 @@ export const FormHiddenFieldWidget = Scrivito.provideWidgetClass(
     attributes: {
       customFieldName: "string",
       hiddenValue: "string",
+      type: [
+        "enum",
+        {
+          values: ["custom", "subscription"],
+        },
+      ],
     },
   },
 );


### PR DESCRIPTION
Similar to this [PR](https://github.com/Scrivito/scrivito_example_app_js/pull/542) but here we don't have the process.env variables, so subscription will always be available to choose it.