### PR TITLE
PT186858825: Fix local develpoment not working on portal app

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "build": "webpack --mode production",
     "start": "webpack --watch --mode development",
+    "link": "cd build && npm link",
+    "link:portal-app": "npm link",
+    "publish:build": "npm run build && cd build && npm publish",
     "eslint": "eslint --max-warnings 0 src/",
     "es-check": "npm run build && es-check es5 './build/**/*.js'",
     "test": "jest"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "webpack --mode production",
     "start": "webpack --watch --mode development",
     "link": "cd build && npm link",
-    "link:portal-app": "npm link",
+    "link:vite-project": "npm link",
     "publish:build": "npm run build && cd build && npm publish",
     "eslint": "eslint --max-warnings 0 src/",
     "es-check": "npm run build && es-check es5 './build/**/*.js'",

--- a/src/Widgets/FormStepContainerWidget/components/HelpTextComponent.tsx
+++ b/src/Widgets/FormStepContainerWidget/components/HelpTextComponent.tsx
@@ -8,7 +8,6 @@ export const HelpText: React.FC<HelpTextProps> = ({ widget }) => {
   return (
     <OverlayTrigger
       placement="top"
-      trigger="hover"
       overlay={
         <Popover>
           <Popover.Body>

--- a/src/Widgets/FormStepContainerWidget/components/MandatoryComponent.tsx
+++ b/src/Widgets/FormStepContainerWidget/components/MandatoryComponent.tsx
@@ -1,11 +1,10 @@
 import * as React from "react";
 import { Popover, OverlayTrigger } from "react-bootstrap";
 
-export const Mandatory = ({}) => {
+export const Mandatory = ({ }) => {
   return (
     <OverlayTrigger
       placement="top"
-      trigger="hover"
       overlay={
         <Popover>
           <Popover.Body>mandatory</Popover.Body>

--- a/src/config/scrivitoConfig.ts
+++ b/src/config/scrivitoConfig.ts
@@ -1,3 +1,5 @@
+import { isEmpty } from "lodash-es";
+
 let _instanceId: string = "";
 
 export const initNeoletterFormWidgets = (instanceId: string): void => {
@@ -10,10 +12,17 @@ export const getInstanceId = (): string => {
 };
 
 function loadWidgets(): void {
-  const widgetImportsContext = require.context(
-    "../Widgets",
-    true,
-    /Widget(Class|Component|EditingConfig)\.tsx?$/,
-  );
-  widgetImportsContext.keys().forEach(widgetImportsContext);
+  if (isEmpty(import.meta)) {
+    const widgetImportsContext = require.context(
+      "../Widgets",
+      true,
+      /Widget(Class|Component|EditingConfig)\.tsx?$/,
+    );
+    widgetImportsContext.keys().forEach(widgetImportsContext);
+
+  } else {
+    (import.meta as any).glob(['../Widgets/**/*WidgetClass.ts', '../Widgets/**/*WidgetComponent.tsx', '../Widgets/**/*WidgetEditingConfig.ts'], {
+      eager: true,
+    });
+  }
 }


### PR DESCRIPTION
This will fix the issue that local development does not work correctly when linking the package into the portal app.
Additionaly removed the `trigger`  prop from 2 components to set to default in order to get rid of console warnings each time we hover over those components