### PR TITLE
Add Neoletter tracking id

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -585,6 +585,17 @@ For the Friendly Captcha, you need to add the following URLs to the "script-src"
 
 For more information regarding CSP, please refer to the CSP section in the Friendly Captcha Docs found [here](https://docs.friendlycaptcha.com/#/csp) or in the Google reCAPTCHA FAQ found [here](https://developers.google.com/recaptcha/docs/faq?hl=de#im-using-content-security-policy-csp-on-my-website.-how-can-i-configure-it-to-work-with-recaptcha)
 
+# Tracking
+
+Enable the Beta Neoletter Tracking capabilities with: 
+
+```js
+import { initNeoletterFormWidgets } from "scrivito-neoletter-form-widgets";
+initNeoletterFormWidgets({
+  tracking: true
+});
+```
+
 # Local Development
 
 To develop and test the package locally, follow these steps:

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ import { initNeoletterFormWidgets } from "scrivito-neoletter-form-widgets";
 initNeoletterFormWidgets();
 
 // If using Scrivito version prior to 1.39.0
-// initNeoletterFormWidgets(process.env.SCRIVITO_TENANT);
+// initNeoletterFormWidgets({ instanceId: process.env.SCRIVITO_TENANT });
 ```
 
 Import the `loadEditingConfigs` function from the package and call it in your editingConfigs.js file also found in the Widgets folder.
@@ -498,9 +498,12 @@ You can only use one of them for your site, but you can change it later if neede
 
 ```js
 import { initNeoletterFormWidgets } from "scrivito-neoletter-form-widgets";
-initNeoletterFormWidgets(process.env.SCRIVITO_TENANT, {
-  siteKey: "your_site_key",
-  captchaType: "google-recaptcha"
+initNeoletterFormWidgets({
+  instanceId: process.env.SCRIVITO_TENANT,
+  captchaOptions: {
+    siteKey: "your_site_key",
+    captchaType: "google-recaptcha"
+  }
 });
 ```
 
@@ -508,9 +511,11 @@ initNeoletterFormWidgets(process.env.SCRIVITO_TENANT, {
 
 ```js
 import { initNeoletterFormWidgets } from "scrivito-neoletter-form-widgets";
-initNeoletterFormWidgets(null, {
-  siteKey: "your_site_key",
-  captchaType: "google-recaptcha"
+initNeoletterFormWidgets({
+  captchaOptions: {
+    siteKey: "your_site_key",
+    captchaType: "google-recaptcha"
+  }
 });
 ```
 
@@ -530,9 +535,12 @@ Finally you need to setup the secret key in Neoletter to be able to use Google r
 
 ```js
 import { initNeoletterFormWidgets } from "scrivito-neoletter-form-widgets";
-initNeoletterFormWidgets(process.env.SCRIVITO_TENANT, {
-  siteKey: "your_site_key",
-  captchaType: "friendly-captcha"
+initNeoletterFormWidgets({
+  instanceId: process.env.SCRIVITO_TENANT,
+  captchaOptions: {
+    siteKey: "your_site_key",
+    captchaType: "friendly-captcha"
+  }
 });
 ```
 
@@ -540,9 +548,11 @@ initNeoletterFormWidgets(process.env.SCRIVITO_TENANT, {
 
 ```js
 import { initNeoletterFormWidgets } from "scrivito-neoletter-form-widgets";
-initNeoletterFormWidgets(null, {
-  siteKey: "your_site_key",
-  captchaType: "friendly-captcha"
+initNeoletterFormWidgets({
+  captchaOptions: {
+    siteKey: "your_site_key",
+    captchaType: "friendly-captcha"
+  }
 });
 ```
 
@@ -614,7 +624,7 @@ Below this import, call the `initNeoletterFormWidgets` function:
 - Using Scrivito version prior to 1.39.0:
 
 ```js
-initNeoletterFormWidgets(process.env.SCRIVITO_TENANT);
+initNeoletterFormWidgets({ instanceId: process.env.SCRIVITO_TENANT });
 ```
 
 - Using Scrivito version 1.39.0 or later:
@@ -674,7 +684,7 @@ Below this import, call the `initNeoletterFormWidgets` function:
 - Using Scrivito version prior to 1.39.0:
 
 ```js
-initNeoletterFormWidgets(process.env.SCRIVITO_TENANT);
+initNeoletterFormWidgets({ instanceId: process.env.SCRIVITO_TENANT });
 ```
 
 - Using Scrivito version 1.39.0 or later:

--- a/src/Widgets/FormStepContainerWidget/utils/appendNeoletterTrackingIDtoFormData.ts
+++ b/src/Widgets/FormStepContainerWidget/utils/appendNeoletterTrackingIDtoFormData.ts
@@ -1,0 +1,25 @@
+const NEOLETTER_TRACKING_ID_KEY = "neo_tid";
+const NEOLETTER_TRACKING_ID_FIELD_NAME = "tracking_id";
+
+/**
+ * Appends the Neoletter tracking ID to the provided FormData object.
+ * @param {FormData} formData - The FormData object to append the tracking ID to.
+ */
+export const appendTrackingIDToFormData = (formData: FormData) => {
+  const trackingID = getNeoletterTrackingID();
+  if (trackingID) {
+    formData.set(NEOLETTER_TRACKING_ID_FIELD_NAME, trackingID);
+  }
+};
+
+/**
+ * Retrieves the Neoletter tracking ID from local storage.
+ * @returns {string} The tracking ID or an empty string if not found or in case of an error.
+ */
+const getNeoletterTrackingID = (): string => {
+  try {
+    return localStorage.getItem(NEOLETTER_TRACKING_ID_KEY) || "";
+  } catch (error) {
+    return "";
+  }
+};

--- a/src/Widgets/FormStepContainerWidget/utils/submitForm.ts
+++ b/src/Widgets/FormStepContainerWidget/utils/submitForm.ts
@@ -1,5 +1,8 @@
 import { Widget } from "scrivito";
+
+import { isTrackingEnabled } from "../../../config/scrivitoConfig";
 import { getFieldName } from "./getFieldName";
+import { appendTrackingIDToFormData } from "./appendNeoletterTrackingIDtoFormData";
 
 export async function submitForm(
   formElement: HTMLFormElement,
@@ -23,7 +26,9 @@ function getFormData(formElement: HTMLFormElement, formWidget: Widget) {
   const data = new FormData(formElement);
   const dataToSend = new FormData();
 
-  appendTrackingIDToFormData(dataToSend);
+  if(isTrackingEnabled()) {
+    appendTrackingIDToFormData(dataToSend);
+  }
 
   // workaround to send all field-names with equal name
   // as a comma separated string
@@ -48,29 +53,3 @@ function getFormData(formElement: HTMLFormElement, formWidget: Widget) {
   }
   return dataToSend;
 }
-
-const NEOLETTER_TRACKING_ID_KEY = "neo_tid";
-const NEOLETTER_TRACKING_ID_FIELD_NAME = "tracking_id";
-
-/**
- * Appends the Neoletter tracking ID to the provided FormData object.
- * @param {FormData} formData - The FormData object to append the tracking ID to.
- */
-const appendTrackingIDToFormData = (formData: FormData) => {
-  const trackingID = getNeoletterTrackingID();
-  if (trackingID) {
-    formData.set(NEOLETTER_TRACKING_ID_FIELD_NAME, trackingID);
-  }
-};
-
-/**
- * Retrieves the Neoletter tracking ID from local storage.
- * @returns {string} The tracking ID or an empty string if not found or in case of an error.
- */
-const getNeoletterTrackingID = (): string => {
-  try {
-    return localStorage.getItem(NEOLETTER_TRACKING_ID_KEY) || "";
-  } catch (error) {
-    return "";
-  }
-};

--- a/src/Widgets/FormStepContainerWidget/utils/submitForm.ts
+++ b/src/Widgets/FormStepContainerWidget/utils/submitForm.ts
@@ -22,6 +22,9 @@ export async function submitForm(
 function getFormData(formElement: HTMLFormElement, formWidget: Widget) {
   const data = new FormData(formElement);
   const dataToSend = new FormData();
+
+  appendTrackingIDToFormData(dataToSend);
+
   // workaround to send all field-names with equal name
   // as a comma separated string
   for (const [name] of data) {
@@ -45,3 +48,29 @@ function getFormData(formElement: HTMLFormElement, formWidget: Widget) {
   }
   return dataToSend;
 }
+
+const NEOLETTER_TRACKING_ID_KEY = "neo_tid";
+const NEOLETTER_TRACKING_ID_FIELD_NAME = "tracking_id";
+
+/**
+ * Appends the Neoletter tracking ID to the provided FormData object.
+ * @param {FormData} formData - The FormData object to append the tracking ID to.
+ */
+const appendTrackingIDToFormData = (formData: FormData) => {
+  const trackingID = getNeoletterTrackingID();
+  if (trackingID) {
+    formData.set(NEOLETTER_TRACKING_ID_FIELD_NAME, trackingID);
+  }
+};
+
+/**
+ * Retrieves the Neoletter tracking ID from local storage.
+ * @returns {string} The tracking ID or an empty string if not found or in case of an error.
+ */
+const getNeoletterTrackingID = (): string => {
+  try {
+    return localStorage.getItem(NEOLETTER_TRACKING_ID_KEY) || "";
+  } catch (error) {
+    return "";
+  }
+};

--- a/src/config/scrivitoConfig.ts
+++ b/src/config/scrivitoConfig.ts
@@ -1,21 +1,23 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as Scrivito from "scrivito";
-import { CaptchaOptions } from "../../types/types";
+import { CaptchaOptions, Options } from "../../types/types";
 import { isEmpty } from "../Widgets/FormStepContainerWidget/utils/lodashPolyfills";
 
 const GLOBAL_OBJ = typeof window !== 'undefined' ? window : global;
 
 export const initNeoletterFormWidgets = (
-	instanceId?: string,
-	captchaOptions?: CaptchaOptions
+	options?: Options
 ): void => {
-	if (instanceId) {
-		(GLOBAL_OBJ as any).neoletterFormInstanceId = instanceId;
+	if (options?.instanceId) {
+		(GLOBAL_OBJ as any).neoletterFormInstanceId = options.instanceId;
 	}
-	(GLOBAL_OBJ as any).neoletterFormCaptchaOptions = captchaOptions
-		? captchaOptions
+
+	(GLOBAL_OBJ as any).neoletterFormCaptchaOptions = options?.captchaOptions
+		? options.captchaOptions
 		: { siteKey: "", captchaType: null };
 
+	(GLOBAL_OBJ as any).tracking = options?.tracking || false
+	
 	loadWidgets();
 	attachCaptchaScript();
 };
@@ -31,6 +33,10 @@ export const getInstanceId = (): string => {
 export const getCaptchaOptions = (): CaptchaOptions => {
 	return (GLOBAL_OBJ as any).neoletterFormCaptchaOptions;
 };
+
+export const isTrackingEnabled = () => {
+	return (GLOBAL_OBJ as any).tracking;
+}
 
 function loadWidgets(): void {
 	if (isEmpty(import.meta)) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,7 +2,13 @@ export interface CaptchaOptions {
   siteKey: string;
   captchaType: "google-recaptcha" | "friendly-captcha" | null;
 }
+
+export interface Options {
+  instanceId?: string
+  captchaOptions?: CaptchaOptions,
+  tracking?: boolean
+}
+
 export declare function initNeoletterFormWidgets(
-  instanceId?: string,
-  captchaOptions?: CaptchaOptions
+  options?: Options
 ): void;

--- a/test/tests/Widgets/FormStepContainerWidget.test.tsx
+++ b/test/tests/Widgets/FormStepContainerWidget.test.tsx
@@ -194,8 +194,11 @@ describe("FormStepContainerWidget", () => {
     const testTrackingID = "test-tracking-id";
 
     beforeAll(() => {
+      // Set tracking flag to true
+      (global as any).tracking = true
+      
       // Mock global fetch function
-      global.fetch = jest.fn().mockImplementationOnce(() =>
+      global.fetch = jest.fn().mockImplementation(() =>
         Promise.resolve({
           status: 200,
           ok: true,

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -19,3 +19,9 @@ export interface CaptchaOptions {
 export type FriendlyCaptchaStartMode = "auto" | "focus" | "none";
 export type FriendlyCaptchaEndpoint = "global" | "eu";
 export type CaptchaTheme = "light" | "dark";
+
+export interface Options {
+  instanceId?: string,
+  captchaOptions?: CaptchaOptions,
+  tracking?: boolean
+}


### PR DESCRIPTION
When the `neo_tid` field is present in the local storage, it is included as the `tracking_id` in the form data which is then transmitted to the Neoletter API.

Assumptions:

- The neo_tid is only accessible in applications that have integrated the "scrivito-neoletter-tracking" package and where user consent has been obtained.
- The presence of a tracking_id does not influence the functionality of the forms. The backend is responsible for deciding whether to use the tracking_id and it currently does so only for subscription forms.

Future Considerations:

It may be possible for editors to control the impact of the `tracking_id` on form submissions via the neoletter GUI. This could be achieved by allowing editors to add specific tags to the form or by for example making the effect dependent on the "accept_term" clause.